### PR TITLE
Add maxResults param

### DIFF
--- a/src/app/ng-select/option-list.ts
+++ b/src/app/ng-select/option-list.ts
@@ -15,6 +15,8 @@ export class OptionList {
     private _hasShown: boolean;
     private _hasSelected: boolean;
 
+    private _maxResults: number = null;
+
     get hasShown(): boolean {
         return this._hasShown;
     }
@@ -67,6 +69,19 @@ export class OptionList {
         this.updateHasSelected();
     }
 
+    /** Value. **/
+
+    get maxResults(): number {
+        return this._maxResults;
+    }
+
+    set maxResults(v: number) {
+        v = typeof v === 'undefined' || v === null ? null : v;
+
+        this._maxResults = v;
+    }
+
+
     /** Selection. **/
 
     get selection(): Array<Option> {
@@ -100,7 +115,11 @@ export class OptionList {
     /** Filter. **/
 
     get filtered(): Array<Option> {
-        return this.options.filter(option => option.shown);
+        if (!this._maxResults) {
+            return this.options.filter((option, idx) => option.shown);
+        } else {
+            return this.options.filter((option, idx) => option.shown).slice(0, this._maxResults);
+        }
     }
 
     get filteredEnabled(): Array<Option> {

--- a/src/app/ng-select/select.component.ts
+++ b/src/app/ng-select/select.component.ts
@@ -29,6 +29,7 @@ export class SelectComponent implements ControlValueAccessor, OnChanges, OnInit 
     @Input() disabled: boolean = false;
     @Input() multiple: boolean = false;
     @Input() noFilter: number = 0;
+    @Input() maxResults: number = null;
 
     // Style settings.
     @Input() highlightColor: string;
@@ -226,6 +227,7 @@ export class SelectComponent implements ControlValueAccessor, OnChanges, OnInit 
         let optionsChanged: boolean = changes.hasOwnProperty('options');
         let noFilterChanged: boolean = changes.hasOwnProperty('noFilter');
         let placeholderChanged: boolean = changes.hasOwnProperty('placeholder');
+        let maxResultsChanged: boolean = changes.hasOwnProperty('maxResults');
 
         if (optionsChanged) {
             this.updateOptionList(changes.options.currentValue);
@@ -237,6 +239,11 @@ export class SelectComponent implements ControlValueAccessor, OnChanges, OnInit 
         if (placeholderChanged) {
             this.updateState();
         }
+
+        if (maxResultsChanged) {
+            this.updateMaxResultsDisplayed();
+        }
+
     }
 
     private updateOptionList(options: Array<IOption>) {
@@ -247,6 +254,10 @@ export class SelectComponent implements ControlValueAccessor, OnChanges, OnInit 
     private updateFilterEnabled() {
         this.filterEnabled = this.optionList.options.length >= this.noFilter;
     }
+
+    private updateMaxResultsDisplayed() {
+        this.optionList.maxResults = this.maxResults;
+    }    
 
     /** Value. **/
 


### PR DESCRIPTION
Add a maxResults parameter to optionally limit the size of the result dropdown for possible performance reasons, assuming large dropdowns will require filtering